### PR TITLE
Remove the Web MM channel from deployment notifications

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -16,7 +16,7 @@ env:
   - name: MATTERMOST_GROUP
     value: "canonical"
   - name: HUBOT_RELEASE_NOTIFICATION_ROOMS
-    value: "web--design,is-outage"
+    value: "is-outage"
   - name: HUBOT_IRC_DEBUG
     value: "true"
   - name: HUBOT_SPREADSHEET_CLIENT_EMAIL


### PR DESCRIPTION
## Done

Remove the Web channel from the site deployment notifications. These notifications are causing a lot of noise and disrupting the purpose of the channel as an internal company place to discuss things.  