### PR TITLE
Small fixes for library figma library alerts

### DIFF
--- a/scripts/figma-library-alerts.js
+++ b/scripts/figma-library-alerts.js
@@ -18,12 +18,22 @@ module.exports = function (robot) {
 
     // Check if X-Goog- header is present, so the callback came from the Google Drive Webhook
     if (req.headers["x-goog-channel-id"]) {
-      let resourceId = req.headers["x-goog-channel-id"];
+      let token = req.headers["x-goog-channel-token"];
       let resourceState = req.headers["x-goog-resource-state"];
-      let message = `Hello library maintainers! :) On Google Drive ${resourceId} changed. Action type: ${resourceState}.  Please update the Figma libraries accordingly.`;
+      let changed = reg.headers["x-goog-changed"];
+      let message = `On Google Drive ${token} changed. Action type: ${resourceState} ${
+        changed ? `Change type: ${changed}` : ""
+      }`;
 
       try {
-        robot.messageRoom(room, message);
+        if (resourceState !== "sync") {
+          if (
+            !changed ||
+            (changed !== "parents" && changed !== "permissions")
+          ) {
+            robot.messageRoom(room, message);
+          }
+        }
       } catch (_error) {
         robot.messageRoom(room, "Whoa, I got an error: " + _error);
         console.log(
@@ -36,7 +46,7 @@ module.exports = function (robot) {
     } else {
       // X-Goog- header not present, use default message which will be used in Github Actions
       let data = req.body;
-      let message = `Hello library maintainers! :) ${data["source"]} has changed. Here is what changed${data["change-summary"]}. Please update the Figma libraries accordingly.`;
+      let message = `${data["source"]} has changed. Changes: ${data["change-summary"]}.`;
 
       try {
         robot.messageRoom(room, message);


### PR DESCRIPTION
Done:
- Using token instead of channel ID for naming the webhook - as recommended in Googles docs
- Google drive webhooks need to be resubscribed every 24h. The webhook will send a message of type sync everytime a webhook is created. So our chat was spammed by sync messages every 24h. So we are now ignoring sync messages.
- We are checking for the changed header now (it doesn't always exist) - if it does exist we are filtering out the `parents` and `permissions` change type - as those have no effect on Figma libraries so we are not interested in them.
- Shortened the message - the long messages got a bit annoying.