### PR TITLE
Ignoring more google drive notification events in figma library alert script

### DIFF
--- a/scripts/figma-library-alerts.js
+++ b/scripts/figma-library-alerts.js
@@ -17,7 +17,7 @@ module.exports = function (robot) {
     let room = "figma-library-maintainers";
     // Check if X-Goog- header is present, so the callback came from the Google Drive Webhook
     if (req.headers["x-goog-channel-id"]) {
-      let token = req.headers["x-goog-channel-token"];
+      const token = req.headers["x-goog-channel-token"];
       let resourceState = req.headers["x-goog-resource-state"];
       let changed = req.headers["x-goog-changed"];
       let message = `On Google Drive ${token} changed. Action type: ${resourceState} ${

--- a/scripts/figma-library-alerts.js
+++ b/scripts/figma-library-alerts.js
@@ -77,6 +77,6 @@ module.exports = function (robot) {
         }
       }
     }
-    return res.end("");
+    return res.status(200).end("");
   });
 };

--- a/scripts/figma-library-alerts.js
+++ b/scripts/figma-library-alerts.js
@@ -28,7 +28,7 @@ module.exports = function (robot) {
         if (resourceState !== "sync" && resourceState !== "add") {
           if (changed) {
             // Split the changed string into an array
-            let changedArray = changed.split(",").map((item) => item.trim());
+            const changedArray = changed.split(",").map((item) => item.trim());
 
             // Define the changes we're not interested in
             const uninterestingChanges = [

--- a/scripts/figma-library-alerts.js
+++ b/scripts/figma-library-alerts.js
@@ -63,7 +63,7 @@ module.exports = function (robot) {
       // X-Goog- header not present, use default message which will be used in Github Actions
       let data = req.body;
       if (data) {
-        let message = `${data["source"]} has changed. Changes: ${data["change-summary"]}.`;
+        const message = `${data["source"]} has changed. Changes: ${data["change-summary"]}.`;
         try {
           robot.messageRoom(room, message);
         } catch (_error) {


### PR DESCRIPTION
- the `add` event seems to fire not when a resource is added to a folder but when content is changed (and other times seemingly randomly). The event that is triggered when something is added to a folder (which is something we are interested in) seems to be event type update, change type children. It doesn't really make sense, and we are receiving a lot of these "false" add notifications, so at the moment it seems best to ignore it.
- We also ignore properties, since that is not something we are interested in.